### PR TITLE
Scale images down

### DIFF
--- a/app/src/main/java/io/islnd/android/islnd/app/FriendAddBackService.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/FriendAddBackService.java
@@ -60,8 +60,8 @@ public class FriendAddBackService extends IntentService {
                 Profile profile = DataUtils.getProfile(this, IslndContract.UserEntry.MY_USER_ID);
                 ProfileResource profileResource = new ProfileResource(
                         profile.getAboutMe(),
-                        ImageUtil.getByteArrayFromUri(this, profile.getProfileImageUri()),
-                        ImageUtil.getByteArrayFromUri(this, profile.getHeaderImageUri()));
+                        ImageUtil.getScaledImageByteArrayFromUri(this, profile.getProfileImageUri()),
+                        ImageUtil.getScaledImageByteArrayFromUri(this, profile.getHeaderImageUri()));
                 String profileResourceKey = CryptoUtil.createAlias();
                 EncryptedResource encryptedResource = new EncryptedResource(
                         profileResource,

--- a/app/src/main/java/io/islnd/android/islnd/messaging/event/EventListBuilder.java
+++ b/app/src/main/java/io/islnd/android/islnd/messaging/event/EventListBuilder.java
@@ -100,7 +100,7 @@ public class EventListBuilder {
         this.eventList.add(new ChangeProfilePictureEvent(
                         getCurrentAlias(),
                         getNewEventId(),
-                        ImageUtil.getByteArrayFromUri(mContext, profileImageUri)));
+                        ImageUtil.getScaledImageByteArrayFromUri(mContext, profileImageUri)));
         return this;
     }
 
@@ -108,7 +108,7 @@ public class EventListBuilder {
         this.eventList.add(new ChangeHeaderPictureEvent(
                         getCurrentAlias(),
                         getNewEventId(),
-                        ImageUtil.getByteArrayFromUri(mContext, headerImageUri)));
+                        ImageUtil.getScaledImageByteArrayFromUri(mContext, headerImageUri)));
         return this;
     }
 


### PR DESCRIPTION
This will scale profile and header images down based on a max pixel dimension. In other words no image height or width will exceed our set pixel constant (Which is 1000 pixels as of now).

With the current constant I am seeing images compressed to as much as 250 kilobytes. I'm still unsure of the max compressed image size with our constant, but I don't think it will get much higher than 250 kb. Most of the time I'm seeing an average of 100 kb.

More research will need to be done to calculate the max compressed file sizes, but for now I think this will be a reliable solution.
