### PR TITLE
Notification query for just the notification table

### DIFF
--- a/app/src/main/java/io/islnd/android/islnd/app/database/IslndContract.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/database/IslndContract.java
@@ -25,6 +25,7 @@ public class IslndContract {
     public static final String PATH_RECEIVED_MESSAGE = "received_message";
     public static final String PATH_OUTGOING_MESSAGE = "outgoing_message";
     public static final String PATH_NOTIFICATION = "notification";
+    public static final String PATH_NOTIFICATION_WITH_USER_DATA = "notification_with_user_data";
 
     public static final class PostEntry implements BaseColumns {
 
@@ -265,6 +266,20 @@ public class IslndContract {
         public static Uri buildNotificationUri(long id) {
             return ContentUris.withAppendedId(CONTENT_URI, id);
         }
+    }
+
+    public static final class NotificationWithUserDataEntry implements BaseColumns {
+        private static final String TAG = NotificationEntry.class.getSimpleName();
+
+        public static final Uri CONTENT_URI =
+                BASE_CONTENT_URI.buildUpon().appendPath(PATH_NOTIFICATION_WITH_USER_DATA).build();
+
+        public static final String CONTENT_TYPE =
+                ContentResolver.CURSOR_DIR_BASE_TYPE + "/" + CONTENT_AUTHORITY + "/" + PATH_NOTIFICATION_WITH_USER_DATA;
+        public static final String CONTENT_ITEM_TYPE =
+                ContentResolver.CURSOR_ITEM_BASE_TYPE + "/" + CONTENT_AUTHORITY + "/" + PATH_NOTIFICATION_WITH_USER_DATA;
+
+        public static final String TABLE_NAME = "notification";
     }
 
     public static final class ReceivedEventEntry implements BaseColumns {

--- a/app/src/main/java/io/islnd/android/islnd/app/database/IslndContract.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/database/IslndContract.java
@@ -269,8 +269,6 @@ public class IslndContract {
     }
 
     public static final class NotificationWithUserDataEntry implements BaseColumns {
-        private static final String TAG = NotificationEntry.class.getSimpleName();
-
         public static final Uri CONTENT_URI =
                 BASE_CONTENT_URI.buildUpon().appendPath(PATH_NOTIFICATION_WITH_USER_DATA).build();
 
@@ -278,8 +276,6 @@ public class IslndContract {
                 ContentResolver.CURSOR_DIR_BASE_TYPE + "/" + CONTENT_AUTHORITY + "/" + PATH_NOTIFICATION_WITH_USER_DATA;
         public static final String CONTENT_ITEM_TYPE =
                 ContentResolver.CURSOR_ITEM_BASE_TYPE + "/" + CONTENT_AUTHORITY + "/" + PATH_NOTIFICATION_WITH_USER_DATA;
-
-        public static final String TABLE_NAME = "notification";
     }
 
     public static final class ReceivedEventEntry implements BaseColumns {

--- a/app/src/main/java/io/islnd/android/islnd/app/database/IslndProvider.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/database/IslndProvider.java
@@ -35,7 +35,7 @@ public class IslndProvider extends ContentProvider {
     static final int RECEIVED_MESSAGE = 1000;
     static final int OUTGOING_MESSAGE = 1100;
     static final int NOTIFICATION = 1200;
-    static final int NOTIFICATION_WITH_USER_DATA = 1201;
+    static final int NOTIFICATION_WITH_USER_DATA = 1300;
 
     private static final String sPostTableUserIdSelection =
             IslndContract.PostEntry.TABLE_NAME +
@@ -699,11 +699,14 @@ public class IslndProvider extends ContentProvider {
                         IslndContract.NotificationEntry.TABLE_NAME,
                         null,
                         values);
-                getContext().getContentResolver().notifyChange(IslndContract.NotificationWithUserDataEntry.CONTENT_URI, null);
-                if ( _id > 0 )
+                if ( _id > 0 ) {
+                    getContext().getContentResolver().notifyChange(
+                            IslndContract.NotificationWithUserDataEntry.CONTENT_URI,
+                            null);
                     returnUri = IslndContract.NotificationEntry.buildNotificationUri(_id);
-                else
+                } else {
                     return null;
+                }
 
                 break;
             }

--- a/app/src/main/java/io/islnd/android/islnd/app/fragments/NotificationsFragment.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/fragments/NotificationsFragment.java
@@ -48,7 +48,7 @@ public class NotificationsFragment extends Fragment {
         mAdapter = new NotificationAdapter(mContext, null);
         final NotificationLoader notificationLoader = new NotificationLoader(
                 mContext,
-                IslndContract.NotificationEntry.CONTENT_URI,
+                IslndContract.NotificationWithUserDataEntry.CONTENT_URI,
                 mAdapter);
         getLoaderManager().initLoader(
                 LoaderId.NOTIFICATION_LOADER_ID,


### PR DESCRIPTION
The NotificationEntry now uses a query of just the notification table. The NotificationWithUserDataEntry uses a query that joins the notification, display name, and profile tables.

This resolves the issue where system notifications get updated on profile and display name changes #80.
