### PR TITLE
Check post user id when invoked

### DIFF
--- a/app/src/main/java/io/islnd/android/islnd/app/adapters/CommentAdapter.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/adapters/CommentAdapter.java
@@ -71,25 +71,27 @@ public class CommentAdapter extends CursorRecyclerViewAdapter<RecyclerView.ViewH
                 holder.profileImage,
                 Uri.parse(cursor.getString(cursor.getColumnIndex(IslndContract.ProfileEntry.COLUMN_PROFILE_IMAGE_URI))));
 
-        if (comment.getUserId() == IslndContract.UserEntry.MY_USER_ID) {
-            holder.view.setOnLongClickListener((View v) -> {
-                final String DELETE_COMMENT = mContext.getString(R.string.delete_comment);
-                final String[] items = {DELETE_COMMENT};
+        holder.view.setOnLongClickListener((View v) -> {
+            if (comment.getUserId() != IslndContract.UserEntry.MY_USER_ID) {
+                return false;
+            }
 
-                AlertDialog.Builder builder = new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog);
-                builder.setItems(items, (DialogInterface dialog, int item) -> {
-                    String itemStr = items[item];
-                    if (itemStr.equals(DELETE_COMMENT)) {
-                        DialogFragment deleteCommentFragment =
-                                DeleteCommentDialog.buildWithArgs(comment.getCommentId());
-                        deleteCommentFragment.show(
-                                ((FragmentActivity) mContext).getSupportFragmentManager(),
-                                mContext.getString(R.string.fragment_delete_comment));
-                    }
-                }).show();
+            final String DELETE_COMMENT = mContext.getString(R.string.delete_comment);
+            final String[] items = {DELETE_COMMENT};
 
-                return true;
-            });
-        }
+            AlertDialog.Builder builder = new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog);
+            builder.setItems(items, (DialogInterface dialog, int item) -> {
+                String itemStr = items[item];
+                if (itemStr.equals(DELETE_COMMENT)) {
+                    DialogFragment deleteCommentFragment =
+                            DeleteCommentDialog.buildWithArgs(comment.getCommentId());
+                    deleteCommentFragment.show(
+                            ((FragmentActivity) mContext).getSupportFragmentManager(),
+                            mContext.getString(R.string.fragment_delete_comment));
+                }
+            }).show();
+
+            return true;
+        });
     }
 }

--- a/app/src/main/java/io/islnd/android/islnd/app/adapters/PostAdapter.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/adapters/PostAdapter.java
@@ -78,25 +78,27 @@ public class PostAdapter extends CursorRecyclerViewAdapter<GlancePostViewHolder>
             ((Activity)mContext).startActivityForResult(viewPostIntent, FeedFragment.DELETE_POST_RESULT);
         });
 
-        if(post.getUserId() == IslndContract.UserEntry.MY_USER_ID) {
-            holder.view.setOnLongClickListener((View v) -> {
-                final String DELETE_POST = mContext.getString(R.string.delete_post);
-                final String[] items = {DELETE_POST};
+        holder.view.setOnLongClickListener((View v) -> {
+            if (post.getUserId() != IslndContract.UserEntry.MY_USER_ID) {
+                return false;
+            }
 
-                AlertDialog.Builder builder = new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog);
-                builder.setItems(items, (DialogInterface dialog, int item) -> {
-                    String itemStr = items[item];
-                    if (itemStr.equals(DELETE_POST)) {
-                        DialogFragment deletePostFragment =
-                                DeletePostDialog.buildWithArgs(post.getPostId());
-                        deletePostFragment.show(
-                                ((FragmentActivity) mContext).getSupportFragmentManager(),
-                                mContext.getString(R.string.fragment_delete_post));
-                    }
-                }).show();
+            final String DELETE_POST = mContext.getString(R.string.delete_post);
+            final String[] items = {DELETE_POST};
 
-                return true;
-            });
-        }
+            AlertDialog.Builder builder = new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog);
+            builder.setItems(items, (DialogInterface dialog, int item) -> {
+                String itemStr = items[item];
+                if (itemStr.equals(DELETE_POST)) {
+                    DialogFragment deletePostFragment =
+                            DeletePostDialog.buildWithArgs(post.getPostId());
+                    deletePostFragment.show(
+                            ((FragmentActivity) mContext).getSupportFragmentManager(),
+                            mContext.getString(R.string.fragment_delete_post));
+                }
+            }).show();
+
+            return true;
+        });
     }
 }


### PR DESCRIPTION
This fixes issue #61

When the feed changed on refresh, the display changed for the new posts, but delete was still bound to the post holders at positions where my posts were.

If my post was in position 2, when a new post came in, there would still be a delete option on the post in position 2, whether or not it was my post.

The code now checks user ID when the listener is invoked. Since it checks at "run time" it uses the information for the post that is currently there
