### PR TITLE
Apply theme in every activity

### DIFF
--- a/app/src/main/java/io/islnd/android/islnd/app/activities/IslndActivity.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/activities/IslndActivity.java
@@ -3,12 +3,14 @@ package io.islnd.android.islnd.app.activities;
 import android.support.v7.app.AppCompatActivity;
 
 import io.islnd.android.islnd.app.SyncAlarm;
+import io.islnd.android.islnd.app.util.Util;
 
 public class IslndActivity extends AppCompatActivity {
 
     @Override
     protected void onResume() {
         super.onResume();
+        Util.applyAppTheme(getApplicationContext());
         SyncAlarm.cancelAlarm(getApplicationContext());
     }
 

--- a/app/src/main/java/io/islnd/android/islnd/app/activities/SplashScreenActivity.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/activities/SplashScreenActivity.java
@@ -37,8 +37,6 @@ public class SplashScreenActivity extends IslndActivity {
         Log.d(TAG, "requestSync");
         resolver.requestSync(syncAccount, IslndContract.CONTENT_AUTHORITY, new Bundle());
 
-        Util.applyAppTheme(this);
-
         Util.setUsesApiKey(mContext, true);
 
         // Visual pause...

--- a/app/src/main/java/io/islnd/android/islnd/app/util/Util.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/util/Util.java
@@ -109,6 +109,7 @@ public class Util {
     }
 
     public static void applyAppTheme(Context context) {
+        Log.d(TAG, "applying app theme...");
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
         String value = sharedPref.getString(AppearancePreferenceFragment.PREFERENCE_THEME_KEY, "1");
 


### PR DESCRIPTION
This PR addresses #51 

Previously there was a chance that the app theme would not be applied as described by issue #51. Applying it in `onResume()` of every activity should ensure it is applied no matter what happens.
