### PR TITLE
Remove support for vector drawables

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,6 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
-        generatedDensities = []
     }
     buildTypes {
         release {
@@ -23,9 +22,6 @@ android {
         }
     }
     productFlavors {
-    }
-    aaptOptions {
-        additionalParameters "--no-version-vectors"
     }
 }
 


### PR DESCRIPTION
My 4.2.2 device was crashing when trying to load vector drawables. Apparently support libs 23.3.0 removed support for vector drawable appcompat.

The changes made to the gradle file will force Android Studio to convert the vector drawables to PNGs at compile time.
