### PR TITLE
Revert "Publish events using async call"

### DIFF
--- a/app/src/main/java/io/islnd/android/islnd/app/EventPublisher.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/EventPublisher.java
@@ -3,7 +3,6 @@ package io.islnd.android.islnd.app;
 import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -76,10 +75,6 @@ public class EventPublisher {
     }
 
     public void publish() {
-        new PublishTask().execute();
-    }
-
-    private void publishEvents() {
         final List<Event> events = this.eventListBuilder.build();
         ContentValues[] values = new ContentValues[events.size()];
         PrivateKey privateKey = Util.getPrivateKey(mContext);
@@ -102,14 +97,5 @@ public class EventPublisher {
                 Util.getSyncAccount(mContext),
                 IslndContract.CONTENT_AUTHORITY,
                 new Bundle());
-    }
-
-    private class PublishTask extends AsyncTask<Void, Void, Void> {
-
-        @Override
-        protected Void doInBackground(Void... params) {
-            publishEvents();
-            return null;
-        }
     }
 }


### PR DESCRIPTION
Reverts Daviddt17/island-android-app#94

When Android is busy with other tasks (from other apps) the async tasks we create are very delayed.
