### PR TITLE
Change mailbox

### DIFF
--- a/app/src/main/java/io/islnd/android/islnd/app/database/DataUtils.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/database/DataUtils.java
@@ -176,7 +176,50 @@ public class DataUtils {
         }
     }
 
+    public static void updateUserOutbox(Context context, int userId, String newOutbox) {
+        Log.d(TAG, "updateUserOutbox by userId");
+        ContentValues values = new ContentValues();
+        values.put(IslndContract.UserEntry.COLUMN_MESSAGE_OUTBOX, newOutbox);
+
+        String selection = IslndContract.UserEntry._ID + " = ?";
+        String[] selectionArgs = new String[]{ Integer.toString(userId) };
+
+        int rowsUpdated = context.getContentResolver().update(
+                IslndContract.UserEntry.CONTENT_URI,
+                values,
+                selection,
+                selectionArgs
+        );
+
+        if (rowsUpdated == 0) {
+            Log.w(TAG, "no outbox updated");
+        }
+    }
+
+    public static void updateUserInbox(Context context, String newInbox, Key publicKey) {
+        Log.d(TAG, "updateUserInbox by publicKey");
+        ContentValues values = new ContentValues();
+        values.put(IslndContract.UserEntry.COLUMN_MESSAGE_INBOX, newInbox);
+
+        String selection = IslndContract.UserEntry.COLUMN_PUBLIC_KEY + " = ?";
+        String[] selectionArgs = new String[]{
+                CryptoUtil.encodeKey(publicKey)
+        };
+
+        int rowsUpdated = context.getContentResolver().update(
+                IslndContract.UserEntry.CONTENT_URI,
+                values,
+                selection,
+                selectionArgs
+        );
+
+        if (rowsUpdated == 0) {
+            Log.w(TAG, "no inbox updated");
+        }
+    }
+
     public static void updateUserOutbox(Context context, String outbox, Key publicKey) {
+        Log.d(TAG, "updateUserOutbox by publicKey");
         ContentValues values = new ContentValues();
         values.put(IslndContract.UserEntry.COLUMN_MESSAGE_OUTBOX, outbox);
 
@@ -185,12 +228,16 @@ public class DataUtils {
                 CryptoUtil.encodeKey(publicKey)
         };
 
-        context.getContentResolver().update(
+        int rowsUpdated = context.getContentResolver().update(
                 IslndContract.UserEntry.CONTENT_URI,
                 values,
                 selection,
                 selectionArgs
         );
+
+        if (rowsUpdated == 0) {
+            Log.w(TAG, "no outbox updated");
+        }
     }
 
     public static int getUserIdForMessageOutbox(Context context, String mailbox) {
@@ -573,9 +620,10 @@ public class DataUtils {
         }
     }
 
-    public static void updateMyUserMailbox(Context context, String newMailbox) {
+    public static void updateMyInbox(Context context, String newInbox) {
+        Log.d(TAG, "updateMyInbox");
         ContentValues values = new ContentValues();
-        values.put(IslndContract.UserEntry.COLUMN_MESSAGE_INBOX, newMailbox);
+        values.put(IslndContract.UserEntry.COLUMN_MESSAGE_INBOX, newInbox);
 
         String selection = IslndContract.UserEntry._ID + " = ?";
         String[] selectionArgs = new String[]{
@@ -644,11 +692,14 @@ public class DataUtils {
         ContentValues values = new ContentValues();
         values.put(IslndContract.AliasEntry.COLUMN_ALIAS, newAlias);
 
-        context.getContentResolver().update(
+        int rowsUpdated = context.getContentResolver().update(
                 IslndContract.AliasEntry.buildAliasWithUserId(userId),
                 values,
                 null,
                 null);
+        if (rowsUpdated == 0) {
+            Log.w(TAG, "no alias updated");
+        }
     }
 
     public static void updateGroupKey(Context context, int userId, String newGroupKeyEncoded) {
@@ -1082,5 +1133,16 @@ public class DataUtils {
                 cursor.close();
             }
         }
+    }
+
+    public static void removeMessageToken(Context context, String mailbox) {
+        Log.d(TAG, "removeMessageToken");
+        String where = IslndContract.MessageTokenEntry.COLUMN_MAILBOX + " = ?";
+        String[] selectionArgs = new String[] { mailbox};
+        context.getContentResolver().delete(
+                IslndContract.MessageTokenEntry.CONTENT_URI,
+                where,
+                selectionArgs
+        );
     }
 }

--- a/app/src/main/java/io/islnd/android/islnd/app/database/IslndProvider.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/database/IslndProvider.java
@@ -1010,6 +1010,11 @@ public class IslndProvider extends ContentProvider {
                         IslndContract.InviteEntry.TABLE_NAME, selection, selectionArgs);
                 break;
             }
+            case MESSAGE_TOKEN: {
+                rowsDeleted = db.delete(
+                        IslndContract.MessageTokenEntry.TABLE_NAME, selection, selectionArgs);
+                break;
+            }
             default:
                 throw new UnsupportedOperationException("Unknown uri: " + uri);
         }

--- a/app/src/main/java/io/islnd/android/islnd/messaging/MailboxHelper.java
+++ b/app/src/main/java/io/islnd/android/islnd/messaging/MailboxHelper.java
@@ -3,6 +3,9 @@ package io.islnd.android.islnd.messaging;
 import android.content.Context;
 import android.util.Log;
 
+import java.security.Key;
+
+import io.islnd.android.islnd.app.FriendAddBackService;
 import io.islnd.android.islnd.app.database.DataUtils;
 import io.islnd.android.islnd.messaging.crypto.CryptoUtil;
 
@@ -12,8 +15,14 @@ public class MailboxHelper {
 
     public static String getAndSetMyNewInbox(Context context) {
         String newInbox = CryptoUtil.getNewMailbox();
-        DataUtils.updateMyUserMailbox(context, newInbox);
+        DataUtils.updateMyInbox(context, newInbox);
         Log.v(TAG, "my new inbox is " + newInbox);
         return newInbox;
+    }
+
+    public static String getAndSetNewInboxForUser(Context context, Key recipientPublicKey) {
+        String newMailbox = CryptoUtil.getNewMailbox();
+        DataUtils.updateUserInbox(context, newMailbox, recipientPublicKey);
+        return newMailbox;
     }
 }

--- a/app/src/main/java/io/islnd/android/islnd/messaging/MessageLayer.java
+++ b/app/src/main/java/io/islnd/android/islnd/messaging/MessageLayer.java
@@ -81,6 +81,7 @@ public class MessageLayer {
         startAddBackJob(context, friendInbox, randomValue, FriendAddBackService.PUBLIC_IDENTITY_JOB);
         startAddBackJob(context, friendInbox, randomValue, FriendAddBackService.SECRET_IDENTITY_JOB);
         startAddBackJob(context, friendInbox, randomValue, FriendAddBackService.PROFILE_JOB);
+        startAddBackJob(context, friendInbox, randomValue, FriendAddBackService.NEW_MAILBOX_JOB);
 
         return newFriend;
     }

--- a/app/src/main/java/io/islnd/android/islnd/messaging/message/MessageBuilder.java
+++ b/app/src/main/java/io/islnd/android/islnd/messaging/message/MessageBuilder.java
@@ -53,6 +53,14 @@ public class MessageBuilder {
                 encodedKey);
     }
 
+    public static Message buildNewMailboxMessage(Context context, String mailbox, String newMailbox) {
+        return new Message(
+                mailbox,
+                getNewMessageIdAndUpdate(context),
+                MessageType.NEW_MAILBOX,
+                newMailbox);
+    }
+
     public static Message buildDeleteMeMessage(Context context, String mailbox) {
         return new Message(
                 mailbox,

--- a/app/src/main/java/io/islnd/android/islnd/messaging/message/MessagePublisher.java
+++ b/app/src/main/java/io/islnd/android/islnd/messaging/message/MessagePublisher.java
@@ -17,6 +17,7 @@ import javax.crypto.SecretKey;
 import io.islnd.android.islnd.app.database.DataUtils;
 import io.islnd.android.islnd.app.database.IslndContract;
 import io.islnd.android.islnd.app.util.Util;
+import io.islnd.android.islnd.messaging.MailboxHelper;
 import io.islnd.android.islnd.messaging.PublicKeyAndInbox;
 import io.islnd.android.islnd.messaging.crypto.CryptoUtil;
 import io.islnd.android.islnd.messaging.crypto.EncryptedMessage;
@@ -77,7 +78,7 @@ public class MessagePublisher {
             SecretKey newGroupKey) {
 
         List<PublicKeyAndInbox> publicKeyAndInboxList = DataUtils.getKeysForOtherUsers(context, userIdToRemove);
-        ContentValues[] values = new ContentValues[publicKeyAndInboxList.size() * 2];
+        ContentValues[] values = new ContentValues[publicKeyAndInboxList.size() * 3];
         initializeArray(values);
 
         PrivateKey myPrivateKey = Util.getPrivateKey(context);
@@ -104,6 +105,19 @@ public class MessagePublisher {
             );
             encryptMessageAndSetToContentValue(
                     newGroupKeyMessage,
+                    myPrivateKey,
+                    publicKeyAndInbox.getPublicKey(),
+                    values[index++],
+                    publicKeyAndInbox.getInbox());
+
+            String newMailbox = MailboxHelper.getAndSetNewInboxForUser(context, publicKeyAndInbox.getPublicKey());
+            final Message newMailboxMessage = MessageBuilder.buildNewMailboxMessage(
+                    context,
+                    publicKeyAndInbox.getInbox(),
+                    newMailbox
+            );
+            encryptMessageAndSetToContentValue(
+                    newMailboxMessage,
                     myPrivateKey,
                     publicKeyAndInbox.getPublicKey(),
                     values[index++],

--- a/app/src/main/java/io/islnd/android/islnd/messaging/message/MessageType.java
+++ b/app/src/main/java/io/islnd/android/islnd/messaging/message/MessageType.java
@@ -6,5 +6,6 @@ public class MessageType {
     public static final int PROFILE = 2;
     public static final int NEW_ALIAS = 3;
     public static final int NEW_GROUP_KEY = 4;
-    public static final int DELETE_ME = 5;
+    public static final int NEW_MAILBOX = 5;
+    public static final int DELETE_ME = 6;
 }


### PR DESCRIPTION
This addresses issue #95 
These messages let the other device check for new messages at a new mailbox. This lets them save bandwidth because they don't have to keep retrieving old messages.
