### PR TITLE
A hack to defer processing comment events

### DIFF
--- a/app/src/main/java/io/islnd/android/islnd/app/sync/EventSyncAdapter.java
+++ b/app/src/main/java/io/islnd/android/islnd/app/sync/EventSyncAdapter.java
@@ -79,6 +79,7 @@ public class EventSyncAdapter extends AbstractThreadedSyncAdapter {
     }
 
     private void getIncomingMessages() {
+        Log.d(TAG, "getIncomingMessages");
         MessageQuery messageQuery = new MessageQuery(getMailboxes());
         Log.v(TAG, "message query " + messageQuery);
         List<EncryptedMessage> encryptedMessages = Rest.postMessageQuery(
@@ -140,6 +141,7 @@ public class EventSyncAdapter extends AbstractThreadedSyncAdapter {
     }
 
     private void pushOutgoingMessages(ContentProviderClient provider) {
+        Log.d(TAG, "pushOutgoingMessages");
         String[] projections = new String[] {
                 IslndContract.OutgoingMessageEntry.COLUMN_MAILBOX,
                 IslndContract.OutgoingMessageEntry.COLUMN_BLOB
@@ -178,9 +180,11 @@ public class EventSyncAdapter extends AbstractThreadedSyncAdapter {
     }
 
     private void getIncomingEvents() {
+        Log.d(TAG, "getIncomingEvents");
         PriorityQueue<Event> comments = new PriorityQueue<>();
         boolean anyNewEventProcessed;
         do {
+            Log.d(TAG, "get events loop");
             anyNewEventProcessed = false;
             List<EncryptedEvent> encryptedEvents = getEncryptedEvents();
             if (encryptedEvents == null) {
@@ -194,6 +198,7 @@ public class EventSyncAdapter extends AbstractThreadedSyncAdapter {
 
             //--Process events in order
             while (!events.isEmpty()) {
+                Log.d(TAG, "process loop");
                 final Event event = events.poll();
                 switch (event.getType()) {
                     case EventType.NEW_COMMENT: {
@@ -222,6 +227,7 @@ public class EventSyncAdapter extends AbstractThreadedSyncAdapter {
     }
 
     private void pushOutgoingEvents(ContentProviderClient provider) {
+        Log.d(TAG, "pushOutgoingEvents");
         String[] projections = new String[] {
                 IslndContract.OutgoingEventEntry.COLUMN_ALIAS,
                 IslndContract.OutgoingEventEntry.COLUMN_BLOB

--- a/app/src/main/java/io/islnd/android/islnd/messaging/event/Event.java
+++ b/app/src/main/java/io/islnd/android/islnd/messaging/event/Event.java
@@ -21,6 +21,9 @@ public abstract class Event implements
     protected final int eventId;
     protected final int eventType;
 
+    //--This is a hack to defer comment processing
+    private int userId;
+
     protected Event(String alias, int eventId, int eventType) {
         this.alias = alias;
         this.eventId = eventId;
@@ -129,5 +132,13 @@ public abstract class Event implements
         }
 
         return null;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public int getUserId() {
+        return this.userId;
     }
 }


### PR DESCRIPTION
because these have dependencies on posts.

If we are friends with user A and user B, and user B made a post that user A commented on...
we need to make sure we process user B's post before the process the comment

Bug details in #118
